### PR TITLE
Adding cards input as alternative to multiple-choice-input

### DIFF
--- a/hackerforms/input_types.py
+++ b/hackerforms/input_types.py
@@ -89,6 +89,24 @@ class MultipleChoiceInput(Input):
             'multiple': self.multiple,
         }
 
+class CardsInput(Input):
+    type = 'cards-input'
+
+    def __init__(self, key: str, label: str, options, multiple: bool = False) -> None:
+        super().__init__(key)
+        self.label = label
+        self.options = options
+        self.multiple = multiple
+    
+    def json(self):
+        return {
+            'type': self.type,
+            'key': self.key,
+            'label': self.label,
+            'options': self.options,
+            'multiple': self.multiple
+        }
+
 class DropdownInput(Input):
     type = 'dropdown-input'
     def __init__(self, key: str, name: str, options: Union[List[str], List[Dict]], multiple: bool = False):

--- a/hackerforms/inputs.py
+++ b/hackerforms/inputs.py
@@ -114,5 +114,20 @@ def read_multiple_choice(message: str, options: Union[List[str], List[Dict]], mu
     '''
     return get_single_value(Page().read_multiple_choice(message, options, multiple).run(button_text))
 
+def read_cards(label: str, options, multiple: bool = False, button_text: str = 'Next'):
+    '''Display multiple clickable cards to the user
+
+    Args:
+        label (str): The text related to this field
+        options (list): The options to display to the user, eg. ['Option 1', 'Option 2'] or [{'label': 'Option 1', 'value': '1'}, {'label': 'Option 2', 'value': '2'}]
+        multiple (bool): Whether the user can select multiple options
+        button_text (str): The text to display on the button that will submit the value
+
+    Returns:
+        list, any: The values/value selected by the user
+    '''
+
+    return get_single_value(Page().read_cards(label, options, multiple).run(button_text))
+
 def get_single_value(answer: Dict):
     return list(answer.values())[0]

--- a/hackerforms/inputs.py
+++ b/hackerforms/inputs.py
@@ -136,14 +136,14 @@ def read_multiple_choice(message: str, options: Union[List[str], List[Dict]], mu
     return get_single_value(Page().read_multiple_choice(message, options, multiple, initial_value).run(button_text))
 
 
-def read_cards(label: str, options, multiple: bool = False, button_text: str = 'Next', initial_value: Union[Union[str, float], List[Union[str, float]]] = None):
+def read_cards(label: str, options: List[Dict], multiple: bool = False, button_text: str = 'Next', initial_value: Union[Union[str, float], List[Union[str, float]]] = None):
     '''Display multiple clickable cards to the user
 
     Args:
         label (str): The text related to this field
         options (list): The options to display to the user, eg. [
                             {'title': 'Option 1', 'image': 'https://image_1.png', 'description': 'option 1 description'}, 
-                            {'label': 'Option 2', 'image': 'https://image_2.png', 'description': 'option 2 description'}]
+                            {'title': 'Option 2', 'image': 'https://image_2.png', 'description': 'option 2 description'}]
         multiple (bool): Whether the user can select multiple options
         button_text (str): The text to display on the button that will submit the value
         initial_value (list): The initial value to display to the user

--- a/hackerforms/page.py
+++ b/hackerforms/page.py
@@ -137,6 +137,21 @@ class Page:
         '''
         self.fields.append(MultipleChoiceInput(key or message, message, options, multiple))
         return self
+    
+    def read_cards(self, label, options, multiple = False, key = None):
+        '''Add a cards input on the page
+
+        Args:
+            label: The text that will be displayed to the user
+            options: The options of the multiple choice, eg. ['Option 1', 'Option 2'] or [{'label': 'Option 1', 'value': '1'}, {'label': 'Option 2', 'value': '2'}]
+            multiple: Whether the user can select multiple options
+            key: The key of the input's value on the form result. Defaults to the label arg
+        
+        Returns:
+            The form object
+        '''
+        self.fields.append(CardsInput(key or label, label, options, multiple))
+        return self
 
     def display(self, message: str):
         '''Add a message to the page

--- a/hackerforms/page.py
+++ b/hackerforms/page.py
@@ -167,7 +167,7 @@ class Page:
             label: The text that will be displayed to the user
             options: The options of the multiple choice, eg. [
                         {'title': 'Option 1', 'image': 'https://image_1.png', 'description': 'option 1 description'}, 
-                        {'label': 'Option 2', 'image': 'https://image_2.png', 'description': 'option 2 description'}]
+                        {'title': 'Option 2', 'image': 'https://image_2.png', 'description': 'option 2 description'}]
             multiple: Whether the user can select multiple options
             initial_value: The initial value of the input
             key: The key of the input's value on the form result. Defaults to the label arg


### PR DESCRIPTION
# Context
Sometimes, you need to add images to options. A good inspiration example is airtable's gallery view:
![image](https://user-images.githubusercontent.com/8538337/168474742-e2f19413-6cef-41ab-bc6e-eb5576e236f3.png)

# Detail

this adds an `read_cards(...)` function that adds this functionality. The Function signature is similar to the `read_multiple_choice(...)` that should be deprecated as a subset in the future